### PR TITLE
Add dual camera assessment feature

### DIFF
--- a/src/crud.py
+++ b/src/crud.py
@@ -1,6 +1,6 @@
 # src/crud.py
 from sqlmodel import select, Session
-from src.models import User, Camera
+from src.models import User, Camera, CameraSide
 from src.database import get_session, engine
 from typing import Optional
 
@@ -26,14 +26,20 @@ def create_camera(camera: Camera) -> Camera:
         return camera
 
 
-def get_cameras() -> list[Camera]:
+def get_cameras(side: CameraSide | None = None) -> list[Camera]:
     with get_session() as session:
-        return session.exec(select(Camera)).all()
+        statement = select(Camera)
+        if side:
+            statement = statement.where(Camera.side == side)
+        return session.exec(statement).all()
 
 
-def get_user_cameras(user_id: int) -> list[Camera]:
+def get_user_cameras(user_id: int, side: CameraSide | None = None) -> list[Camera]:
     with get_session() as session:
-        return session.exec(select(Camera).where(Camera.user_id == user_id)).all()
+        statement = select(Camera).where(Camera.user_id == user_id)
+        if side:
+            statement = statement.where(Camera.side == side)
+        return session.exec(statement).all()
     
 def get_camera_by_id(camera_id: int) -> Optional[Camera]:
     with Session(engine) as session:

--- a/src/dual_assessment.py
+++ b/src/dual_assessment.py
@@ -1,0 +1,28 @@
+from typing import Tuple
+import cv2
+from .inference import YoloPoseSkeleton
+from .reba_score import compute_reba_score
+from .rula_score import compute_rula_score
+
+class DualCameraAssessment:
+    """Combine two camera views (front and side) for ergonomic assessment."""
+    def __init__(self, front_cam_id: int, side_cam_id: int, operator: str = "default"):
+        self.front_detector = YoloPoseSkeleton(cam_id=front_cam_id, operator=operator)
+        self.side_detector = YoloPoseSkeleton(cam_id=side_cam_id, operator=operator)
+
+    def process(self, front_frame, side_frame) -> Tuple[cv2.Mat, float, float]:
+        angles_front, _ = self.front_detector.detect_and_compute_angles(front_frame)
+        angles_side, _ = self.side_detector.detect_and_compute_angles(side_frame)
+
+        if not angles_front or not angles_side:
+            return front_frame, None, None
+
+        combined = (angles_front[0] + angles_side[0]) / 2.0
+        angle_dict = self.front_detector.convert_angles_to_dict(combined)
+
+        reba_score, reba_table = compute_reba_score(angle_dict)
+        rula_score, rula_table = compute_rula_score(angle_dict)
+
+        self.front_detector._send_data_async([], combined, reba_table, rula_table, reba_score, rula_score)
+
+        return front_frame, reba_score, rula_score

--- a/src/models.py
+++ b/src/models.py
@@ -1,5 +1,11 @@
 from sqlmodel import SQLModel, Field, Relationship
 from typing import Optional, List
+from enum import Enum
+
+
+class CameraSide(str, Enum):
+    FRONT = "front"
+    SIDE = "side"
 
 
 class User(SQLModel, table=True):
@@ -14,6 +20,7 @@ class Camera(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     user_id: int = Field(foreign_key="user.id")
     url: str
-    
+    side: CameraSide = Field(sa_column_kwargs={"nullable": False})
+
     user: Optional[User] = Relationship(back_populates="cameras")
 


### PR DESCRIPTION
## Summary
- add `CameraSide` enum and camera orientation to model
- extend CRUD and API to filter cameras by side
- create dual camera assessment for front and side cameras
- expose `/dual_stream/{front_id}/{side_id}` endpoint
- ensure FastAPI app runs with uvicorn when executed directly

## Testing
- `python3 -m pip install --quiet -r requirements.txt`
- `git ls-files '*.py' -z | xargs -0 python3 -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6874e149a48c83289425a990388a4ad3